### PR TITLE
Gracefully handle invocation with zero arguments

### DIFF
--- a/gh-skeleton
+++ b/gh-skeleton
@@ -288,7 +288,13 @@ configure_user_branch_protection() {
 CHANGE_DIR=""
 PARAMS=""
 
-# Parse command line arguments
+# If there are no arguments then print the usage and exit.
+if [ $# -eq 0 ]; then
+  echo "${USAGE}"
+  exit 0
+fi
+
+# Parse command line arguments.
 while (("$#")); do
   case "$1" in
     -c | --change-dir)

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -8,7 +8,7 @@ DEFAULT_BRANCH="develop"
 DEST_ORG="cisagov"
 SRC_ORG="cisagov"
 
-# Define terminal colors for use in logger functions
+# Define terminal colors for use in logger functions.
 BLUE="\x1B[34m"
 GREEN="\x1B[32m"
 RED="\x1B[31m"
@@ -284,7 +284,7 @@ configure_user_branch_protection() {
     }" | gh api "/repos/${dest_org}/${dest_repo}/branches/${branch}/protection" --method PUT --input -
 }
 
-# Initialize positional parameters and flag variables
+# Initialize positional parameters and flag variables.
 CHANGE_DIR=""
 PARAMS=""
 
@@ -313,18 +313,18 @@ while (("$#")); do
       SRC_ORG="$2"
       shift
       ;;
-    -*) # unsupported flags
+    -*) # Handle unsupported flags.
       echo "Error: Unsupported skeleton flag $1" >&2
       exit 255
       ;;
-    *) # preserve positional arguments
+    *) # Preserve positional arguments.
       PARAMS="$PARAMS $1"
       ;;
   esac
   shift
 done
 
-# set positional arguments in their proper place
+# Set positional arguments in their proper place.
 eval set -- "$PARAMS"
 
 case "$1" in


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the ability to gracefully handle a call to the extension with zero arguments. 

## 💭 Motivation and context ##

The current version of will error out when called with no arguments:
```console
❱ gh skeleton
~/.local/share/gh/extensions/gh-skeleton/gh-skeleton: line 327: $1: unbound variable
```

This PR will print the usage information, which follows the pattern of other `gh` subcommands. 

## 🧪 Testing ##

Tested on local development machine and in continuous integration.

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
