### PR TITLE
Fix broken calls caused by breaking changes in gh command

### DIFF
--- a/gh-skeleton
+++ b/gh-skeleton
@@ -110,6 +110,11 @@ clone_repo() {
   log_info "Adding a new remote origin for the repository."
   git -C "${dest_repo}" remote add origin git@github.com:"${dest_org}/${dest_repo}".git
 
+  log_info "Setting base repository for pull request and issue creation."
+  # TODO: Replace with a gh command when it is implemented.
+  # See: https://github.com/cli/cli/issues/2300
+  git -C "${dest_repo}" config --local --add "remote.origin.gh-resolved" "base"
+
   cd "${dest_repo}"
 
   log_info "Disabling pushing to the upstream (parent) repository."
@@ -170,7 +175,6 @@ END_OF_LINE
       log_info "Pushing ${DEFAULT_BRANCH} and first-commit branches to the remote."
       git push origin "${DEFAULT_BRANCH}" first-commits --set-upstream
       log_info "Opening a new pull request for the first-commits branch."
-      log_info "If prompted, please select ${dest_org}/${dest_repo} as the base repository."
       gh pr create --title "First commits" --assignee=@me --web
       ;;
     failed)

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -107,6 +107,9 @@ clone_repo() {
   log_info "Cloning skeleton remote repository to the new local repository."
   git clone --origin "${src_repo}" git@github.com:"${src_org}/${src_repo}".git "${dest_repo}"
 
+  log_info "Adding a new remote origin for the repository."
+  git -C "${dest_repo}" remote add origin git@github.com:"${dest_org}/${dest_repo}".git
+
   cd "${dest_repo}"
 
   log_info "Disabling pushing to the upstream (parent) repository."
@@ -160,10 +163,8 @@ END_OF_LINE
     created)
       log_ok "The remote repository ${dest_org}/${dest_repo} was successfully created."
       ;;&
-    exists | failed)
-      log_info "Adding a new remote origin for the repository."
-      # We can add the remote origin now since gh was unable to do it.
-      git remote add origin git@github.com:"${dest_org}/${dest_repo}".git
+    exists)
+      log_info "The remote repository ${dest_org}/${dest_repo} already existed."
       ;;&
     created | exists)
       log_info "Pushing ${DEFAULT_BRANCH} and first-commit branches to the remote."

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -291,6 +291,10 @@ configure_user_branch_protection() {
     }" | gh api "/repos/${dest_org}/${dest_repo}/branches/${branch}/protection" --method PUT --input - 1> /dev/null
 }
 
+################################################################################
+# Script execution begins here.
+################################################################################
+
 # Initialize positional parameters and flag variables.
 CHANGE_DIR=""
 PARAMS=""

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -208,7 +208,7 @@ configure_repo_options() {
       delete_branch_on_merge: true,
       private: false,
       visibility: \"public\"
-    }" | gh api "/repos/${dest_org}/${dest_repo}" --method PATCH --input -
+    }" | gh api "/repos/${dest_org}/${dest_repo}" --method PATCH --input - 1> /dev/null
 }
 
 configure_branch_protection() {
@@ -259,7 +259,7 @@ configure_org_branch_protection() {
         teams: [],
         apps: [],
       },
-    }" | gh api "/repos/${dest_org}/${dest_repo}/branches/${branch}/protection" --method PUT --input -
+    }" | gh api "/repos/${dest_org}/${dest_repo}/branches/${branch}/protection" --method PUT --input - 1> /dev/null
 }
 
 configure_user_branch_protection() {
@@ -282,7 +282,7 @@ configure_user_branch_protection() {
         required_approving_review_count: 2,
       },
       restrictions: null,
-    }" | gh api "/repos/${dest_org}/${dest_repo}/branches/${branch}/protection" --method PUT --input -
+    }" | gh api "/repos/${dest_org}/${dest_repo}/branches/${branch}/protection" --method PUT --input - 1> /dev/null
 }
 
 # Initialize positional parameters and flag variables.

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -225,10 +225,12 @@ configure_branch_protection() {
 
   log_info "Determining organization type for $dest_org."
   is_real_org=true
-  gh api "/orgs/$dest_org" --silent || is_real_org=false
+  gh api "/orgs/$dest_org" --silent 2> /dev/null || is_real_org=false
   if [ $is_real_org = true ]; then
+    log_ok "Organization $dest_org is a true organization."
     configure_org_branch_protection "$dest_repo" "$dest_org" "$branch"
   else
+    log_ok "Organization $dest_org is a personal account."
     configure_user_branch_protection "$dest_repo" "$dest_org" "$branch"
   fi
 }

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -152,7 +152,7 @@ END_OF_LINE
     # Note that gh will attempt to add the remote origin and will throw an error
     # if it already exists.  We'll add the origin later if gh fails.
     remote_repo_status="created"
-    gh repo create --public --confirm "${dest_org}/${dest_repo}" || remote_repo_status="failed"
+    gh repo create --public "${dest_org}/${dest_repo}" || remote_repo_status="failed"
   fi
 
   # Handle the different outcomes of the remote repository.

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -157,8 +157,6 @@ END_OF_LINE
   else
     log_warn "${dest_org}/${dest_repo} does not yet exist."
     log_info "Attempting to create a new remote repository."
-    # Note that gh will attempt to add the remote origin and will throw an error
-    # if it already exists.  We'll add the origin later if gh fails.
     remote_repo_status="created"
     gh repo create --public "${dest_org}/${dest_repo}" || remote_repo_status="failed"
   fi


### PR DESCRIPTION
## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Undocumented changes to the GitHub CLI syntax and semantics are causing this extension to fail. 
This PR realigns the `gh` calls to the new release: https://github.com/cli/cli/releases/tag/v2.10.1

It also cleans up a couple of quality-of-life issues that are clearer with the new `gh` command.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Issues: 
- Deprecated `--confirm` option on `gh repo create` was causing an error message to be emitted.  
- `gh repo create` no longer sets the `origin` on an existing repo.  Upon push `git` would fail as the remote was not defined.

Improvements:
- Automatically sets the "base" repository for PRs and issues.  This used to be a prompt asking the user to choose between the new clone, and the source skeleton.
- Suppressed json spews from `gh` API calls

Root `gh` cli causes: 
- https://github.com/cli/cli/pull/4578
- https://github.com/cli/cli/issues/4906

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested by creating repositories in my account. 
For future reference you can install a checked out version of an extension by issuing this command from inside the repo.  This shortens the development / debugging cycle to 0:

```shell
gh extension install .
```

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
