### PR TITLE
Update branch protection settings

### DIFF
--- a/gh-skeleton
+++ b/gh-skeleton
@@ -243,29 +243,29 @@ configure_org_branch_protection() {
   log_info "Configuring organization branch protection for ${dest_org}/${dest_repo}/${branch}."
 
   jq -n "{
+      enforce_admins: true,
+      required_conversation_resolution: true,
+      required_pull_request_reviews: {
+        dismiss_stale_reviews: false,
+        dismissal_restrictions: {
+          teams: [],
+          users: []
+        },
+        require_code_owner_reviews: true,
+        required_approving_review_count: 2
+      },
       required_status_checks: {
-        strict: true,
         checks: [
           {
             context: \"lint\"
           }
-        ]
-      },
-      enforce_admins: true,
-      required_conversation_resolution: true,
-      required_pull_request_reviews: {
-        dismissal_restrictions: {
-          users: [],
-          teams: []
-        },
-        dismiss_stale_reviews: false,
-        require_code_owner_reviews: true,
-        required_approving_review_count: 2
+        ],
+        strict: true
       },
       restrictions: {
-        users: [],
+        apps: [],
         teams: [],
-        apps: []
+        users: []
       }
     }" | gh api "/repos/${dest_org}/${dest_repo}/branches/${branch}/protection" --method PUT --input - 1> /dev/null
 }
@@ -278,20 +278,20 @@ configure_user_branch_protection() {
   log_info "Configuring user branch protection for ${dest_org}/${dest_repo}/${branch}."
 
   jq -n "{
-      required_status_checks: {
-        strict: true,
-        checks: [
-          {
-            context: \"lint\"
-          }
-        ]
-      },
       enforce_admins: true,
       required_conversation_resolution: true,
       required_pull_request_reviews: {
         dismiss_stale_reviews: false,
         require_code_owner_reviews: true,
         required_approving_review_count: 2
+      },
+      required_status_checks: {
+        checks: [
+          {
+            context: \"lint\"
+          }
+        ],
+        strict: true
       },
       restrictions: null
     }" | gh api "/repos/${dest_org}/${dest_repo}/branches/${branch}/protection" --method PUT --input - 1> /dev/null

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -245,7 +245,7 @@ configure_org_branch_protection() {
   jq -n "{
       required_status_checks: {
         strict: true,
-        contexts: [\"lint\", \"test\", \"CodeQL\"]
+        contexts: [\"lint\"]
       },
       enforce_admins: true,
       required_conversation_resolution: true,
@@ -276,7 +276,7 @@ configure_user_branch_protection() {
   jq -n "{
       required_status_checks: {
         strict: true,
-        contexts: [\"lint\", \"test\", \"CodeQL\"]
+        contexts: [\"lint\"]
       },
       enforce_admins: true,
       required_conversation_resolution: true,

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -245,24 +245,24 @@ configure_org_branch_protection() {
   jq -n "{
       required_status_checks: {
         strict: true,
-        contexts: [\"lint\", \"test\", \"CodeQL\"],
+        contexts: [\"lint\", \"test\", \"CodeQL\"]
       },
       enforce_admins: true,
       required_conversation_resolution: true,
       required_pull_request_reviews: {
         dismissal_restrictions: {
           users: [],
-          teams: [],
+          teams: []
         },
         dismiss_stale_reviews: false,
         require_code_owner_reviews: true,
-        required_approving_review_count: 2,
+        required_approving_review_count: 2
       },
       restrictions: {
         users: [],
         teams: [],
-        apps: [],
-      },
+        apps: []
+      }
     }" | gh api "/repos/${dest_org}/${dest_repo}/branches/${branch}/protection" --method PUT --input - 1> /dev/null
 }
 
@@ -276,16 +276,16 @@ configure_user_branch_protection() {
   jq -n "{
       required_status_checks: {
         strict: true,
-        contexts: [\"lint\", \"test\", \"CodeQL\"],
+        contexts: [\"lint\", \"test\", \"CodeQL\"]
       },
       enforce_admins: true,
       required_conversation_resolution: true,
       required_pull_request_reviews: {
         dismiss_stale_reviews: false,
         require_code_owner_reviews: true,
-        required_approving_review_count: 2,
+        required_approving_review_count: 2
       },
-      restrictions: null,
+      restrictions: null
     }" | gh api "/repos/${dest_org}/${dest_repo}/branches/${branch}/protection" --method PUT --input - 1> /dev/null
 }
 

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -245,7 +245,11 @@ configure_org_branch_protection() {
   jq -n "{
       required_status_checks: {
         strict: true,
-        contexts: [\"lint\"]
+        checks: [
+          {
+            context: \"lint\"
+          }
+        ]
       },
       enforce_admins: true,
       required_conversation_resolution: true,
@@ -276,7 +280,11 @@ configure_user_branch_protection() {
   jq -n "{
       required_status_checks: {
         strict: true,
-        contexts: [\"lint\"]
+        checks: [
+          {
+            context: \"lint\"
+          }
+        ]
       },
       enforce_admins: true,
       required_conversation_resolution: true,


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request does the following:
- Remove trailing commas from the JSON blobs
- Pares down the tests that are required to just the `lint` job
- Updates the properties for the `required_status_checks` parameter
- Ensure that JSON blob object properties are sorted alphabetically
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

- Trailing commas are invalid JSON syntax so we should not have them (even if `jq` currently plays nice with them)
- The _only_ test that is guaranteed to be in any repository that descends from our skeletons is the `lint` job
- The `contexts` property has been deprecated in favor of the `checks` property per the [documentation](https://docs.github.com/en/rest/branches/branch-protection?apiVersion=2022-11-28#update-branch-protection)
- Sorting object/dict keys/properties alphabetically is a standard practice for our code
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I used this change when updating required status checks manually using the `GitHub CLI.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
