### PR TITLE
Adjust the text replacement logic

### DIFF
--- a/gh-skeleton
+++ b/gh-skeleton
@@ -121,7 +121,7 @@ clone_repo() {
   git remote set-url --push "${src_repo}" no_push
 
   log_info "Searching and replacing repository name in source files."
-  find . -path './.git' -prune -o -type f -exec \
+  find . -path './.git' -prune -o -not -path './.github/dependabot.yml' -type f -exec \
     perl -pi -e "s/${src_repo}/${dest_repo}/g" {} \;
 
   log_info "Staging modified files."

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -121,8 +121,9 @@ clone_repo() {
   git remote set-url --push "${src_repo}" no_push
 
   log_info "Searching and replacing repository name in source files."
-  find . -path './.git' -prune -o -not -path './.github/dependabot.yml' -type f -exec \
-    perl -pi -e "s/${src_repo}/${dest_repo}/g" {} \;
+  find . -path './.git' -prune -o -not -path './.github/dependabot.yml' -type f \
+    -exec perl -pi -e "s/${src_org}\/${src_repo}/${dest_org}\/${dest_repo}/g" {} \; \
+    -exec perl -pi -e "s/${src_repo}/${dest_repo}/g" {} \;
 
   log_info "Staging modified files."
   git add --verbose .

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -121,7 +121,7 @@ clone_repo() {
   git remote set-url --push "${src_repo}" no_push
 
   log_info "Searching and replacing repository name in source files."
-  find . \( ! -regex '.*/\.git/.*' \) -type f -exec \
+  find . -path './.git' -prune -o -type f -exec \
     perl -pi -e "s/${src_repo}/${dest_repo}/g" {} \;
 
   log_info "Staging modified files."


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adjusts the functionality of the repository name replacement logic in the following ways:
- Change how the `.git/` directory is ignored.
- Do not change the `.github/dependabot.yml` file.
- Also perform a replacement of `<src_org>/<src_repo>` and not just `<src_repo>`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I originally looked at this to handle the second bullet point of the above list because there are attribution comments in the Dependabot configuration file. These should not be replaced in repositories based on a skeleton project and there is nothing else that would warrant replacement in that file so it is safe to ignore it completely. While looking at the logic I noticed that the `find` seemed to inefficiently ignore the `.git/` directory and I have run into a problem when using this tool to start projects in my personal account where I have instances of `cisagov/<new_repo_name>` such as in the README badges.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I tested the find logic in my WSL container and on my work MacBook to check the logic under both Linux and macOS systems.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
