### PR TITLE
Assigning initial version 0.0.1 for new repository

### DIFF
--- a/gh-skeleton
+++ b/gh-skeleton
@@ -88,6 +88,69 @@ print_available_skeletons() {
     --template="${TEMPLATE}" | sort
 }
 
+# Function to read version files from .pre-commit-config.yaml
+get_version_files() {
+  # Check if .pre-commit-config.yaml exists
+  if [[ ! -f ".pre-commit-config.yaml" ]]; then
+    log_error ".pre-commit-config.yaml not found!"
+    exit 1
+  fi
+
+  # Read the repository URL from .pre-commit-config.yaml
+  log_info "Reading repository URL from .pre-commit-config.yaml"
+  bump_version_repo_url=$(yq e '.repos[0].repo' .pre-commit-config.yaml)
+
+  if [[ -z "$bump_version_repo_url" ]]; then
+    log_error "Repository URL not found in .pre-commit-config.yaml!"
+    exit 1
+  fi
+
+  # Define the path to the bump-version file in the repository
+  bump_version_url="${bump_version_repo_url}/raw/develop/bump-version"
+
+  # Download the bump-version.yaml file from the repository
+  log_info "Downloading bump version file from ${bump_version_url}"
+  curl -o bump-version.yaml "${bump_version_url}"
+
+  if [[ ! -f "bump-version" ]]; then
+    log_error "Failed to download bump-version.yaml file!"
+    exit 1
+  fi
+
+  # Extract the list of version files from the VERSION_FILE variable in bump-version.yaml
+  log_info "Reading VERSION_FILE from bump-version.yaml"
+  yq e '.VERSION_FILE[]' bump-version
+}
+
+# Set INITIAL_VERSION to 0.0.1 by default unless provided
+INITIAL_VERSION="${INITIAL_VERSION:-0.0.1}"
+
+# Function to update the version in all specified files
+update_version_in_files() {
+  local new_version=$1
+  local version_files=$(get_version_files)  # Assume this function fetches version files
+
+  for file in $version_files; do
+    if [[ -f "$file" ]]; then
+      log_info "Updating version in $file"
+      perl -pi -e "s/(version[:=]?\s*)[^\s\"']+/\\1$new_version/g" "$file"
+    else
+      log_warn "$file not found, skipping."
+    fi
+  done
+
+  log_info "Staging updated files."
+  git add --verbose .
+
+  log_info "Committing updated version files."
+  git commit --message "Set initial version to $new_version"
+}
+
+# Call the update_version_in_files function with INITIAL_VERSION
+log_info "Updating the initial version to $INITIAL_VERSION in all relevant files."
+update_version_in_files "$INITIAL_VERSION"
+
+
 clone_repo() {
   src_repo=$1
   dest_repo=$2
@@ -131,18 +194,6 @@ clone_repo() {
   log_info "Committing staged files to the ${DEFAULT_BRANCH} branch."
   git commit --message "Rename repository references after clone"
 
-  # Assigning the initial version
-
-  log_info "Creating an initial version 0.0.1 for the new repository."
-
-  echo "0.0.1" > VERSION
-
-  log_info "Staging the version file."
-  git add VERSION
-
-  log_info "Committing the inital version 0.0.1"
-  git commit --message "Set initial version to 0.0.1"
-
   log_info "Creating the lineage.yml file."
   cat << END_OF_LINE > .github/lineage.yml
 ---
@@ -183,8 +234,10 @@ END_OF_LINE
       log_info "The remote repository ${dest_org}/${dest_repo} already existed."
       ;;&
     created | exists)
-      log_info "Pushing ${DEFAULT_BRANCH} and first-commit branches to the remote."
-      git push origin "${DEFAULT_BRANCH}" first-commits --set-upstream
+      log_info "Pushing ${DEFAULT_BRANCH}, first-commits to the remote."
+      git push origin "${DEFAULT_BRANCH}" --set-upstream
+      git push origin first-commits --set-upstream
+      
       log_info "Opening a new pull request for the first-commits branch."
       gh pr create --title "First commits" --assignee=@me --web
       ;;

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -131,6 +131,18 @@ clone_repo() {
   log_info "Committing staged files to the ${DEFAULT_BRANCH} branch."
   git commit --message "Rename repository references after clone"
 
+  # Assigning the initial version
+
+  log_info "Creating an initial version 1.0.0 for the new repository."
+
+  echo "1.0.0" > VERSION
+
+  log_info "Staging the version file."
+  git add VERSION
+
+  log_info "Committing the inital version 1.0.0"
+  git commit --message "Set initial version to 1.0.0"
+
   log_info "Creating the lineage.yml file."
   cat << END_OF_LINE > .github/lineage.yml
 ---

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -108,17 +108,17 @@ get_version_files() {
   # Define the path to the bump-version file in the repository
   bump_version_url="${bump_version_repo_url}/raw/develop/bump-version"
 
-  # Download the bump-version.yaml file from the repository
+  # Download the bump-version file from the repository
   log_info "Downloading bump version file from ${bump_version_url}"
-  curl -o bump-version.yaml "${bump_version_url}"
+  curl -o bump-version "${bump_version_url}"
 
   if [[ ! -f "bump-version" ]]; then
-    log_error "Failed to download bump-version.yaml file!"
+    log_error "Failed to download bump-version file!"
     exit 1
   fi
 
-  # Extract the list of version files from the VERSION_FILE variable in bump-version.yaml
-  log_info "Reading VERSION_FILE from bump-version.yaml"
+  # Extract the list of version files from the VERSION_FILE variable in bump-version
+  log_info "Reading VERSION_FILE from bump-version"
   yq e '.VERSION_FILE[]' bump-version
 }
 
@@ -128,7 +128,7 @@ INITIAL_VERSION="${INITIAL_VERSION:-0.0.1}"
 # Function to update the version in all specified files
 update_version_in_files() {
   local new_version=$1
-  local version_files=$(get_version_files)  # Assume this function fetches version files
+  local version_files=$(get_version_files)
 
   for file in $version_files; do
     if [[ -f "$file" ]]; then
@@ -145,6 +145,10 @@ update_version_in_files() {
   log_info "Committing updated version files."
   git commit --message "Set initial version to $new_version"
 }
+
+# Directly call the function without the log message
+update_version_in_files "$INITIAL_VERSION"
+
 
 # Call the update_version_in_files function with INITIAL_VERSION
 log_info "Updating the initial version to $INITIAL_VERSION in all relevant files."

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -133,15 +133,15 @@ clone_repo() {
 
   # Assigning the initial version
 
-  log_info "Creating an initial version 1.0.0 for the new repository."
+  log_info "Creating an initial version 0.0.1 for the new repository."
 
-  echo "1.0.0" > VERSION
+  echo "0.0.1" > VERSION
 
   log_info "Staging the version file."
   git add VERSION
 
-  log_info "Committing the inital version 1.0.0"
-  git commit --message "Set initial version to 1.0.0"
+  log_info "Committing the inital version 0.0.1"
+  git commit --message "Set initial version to 0.0.1"
 
   log_info "Creating the lineage.yml file."
   cat << END_OF_LINE > .github/lineage.yml

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -32,8 +32,8 @@ log_error() {
 }
 
 # Determine if an executable is in the PATH
-if ! type -p perl > /dev/null; then
-  log_error "Perl not found on the system and is required."
+if ! type -p sed > /dev/null; then
+  log_error "sed not found on the system and is required."
   exit 1
 fi
 
@@ -88,52 +88,35 @@ print_available_skeletons() {
     --template="${TEMPLATE}" | sort
 }
 
-# Function to read version files from .pre-commit-config.yaml
+# Function to read version files from current repository
 get_version_files() {
-  # Check if .pre-commit-config.yaml exists
-  if [[ ! -f ".pre-commit-config.yaml" ]]; then
-    log_error ".pre-commit-config.yaml not found!"
+  # Look for common version files in the current repository
+  log_info "Searching for common version files in the repository."
+
+  # You can add more file names as per your repository's convention
+  version_files=$(find . -maxdepth 2 -type f \( -name "README.md" -o -name "VERSION" -o -name "setup.py" -o -name "package.json" \))
+
+  if [[ -z "$version_files" ]]; then
+    log_error "No version files found!"
     exit 1
   fi
 
-  # Read the repository URL from .pre-commit-config.yaml
-  log_info "Reading repository URL from .pre-commit-config.yaml"
-  bump_version_repo_url=$(yq e '.repos[0].repo' .pre-commit-config.yaml)
-
-  if [[ -z "$bump_version_repo_url" ]]; then
-    log_error "Repository URL not found in .pre-commit-config.yaml!"
-    exit 1
-  fi
-
-  # Define the path to the bump-version file in the repository
-  bump_version_url="${bump_version_repo_url}/raw/develop/bump-version"
-
-  # Download the bump-version file from the repository
-  log_info "Downloading bump version file from ${bump_version_url}"
-  curl -o bump-version "${bump_version_url}"
-
-  if [[ ! -f "bump-version" ]]; then
-    log_error "Failed to download bump-version file!"
-    exit 1
-  fi
-
-  # Extract the list of version files from the VERSION_FILE variable in bump-version
-  log_info "Reading VERSION_FILE from bump-version"
-  yq e '.VERSION_FILE[]' bump-version
+  echo "$version_files"
 }
 
 # Set INITIAL_VERSION to 0.0.1 by default unless provided
 INITIAL_VERSION="${INITIAL_VERSION:-0.0.1}"
 
 # Function to update the version in all specified files
+# Function to update the version in all specified files
 update_version_in_files() {
   local new_version=$1
-  local version_files=$(get_version_files)
+  local version_files=$(get_version_files)  # Fetch version files from the repository
 
   for file in $version_files; do
     if [[ -f "$file" ]]; then
       log_info "Updating version in $file"
-      perl -pi -e "s/(version[:=]?\s*)[^\s\"']+/\\1$new_version/g" "$file"
+      sed -i "s/\(version[:=]\s*\)[^\s\"']*/\1$new_version/" "$file"
     else
       log_warn "$file not found, skipping."
     fi
@@ -145,6 +128,7 @@ update_version_in_files() {
   log_info "Committing updated version files."
   git commit --message "Set initial version to $new_version"
 }
+
 
 # Directly call the function without the log message
 update_version_in_files "$INITIAL_VERSION"
@@ -189,8 +173,8 @@ clone_repo() {
 
   log_info "Searching and replacing repository name in source files."
   find . -path './.git' -prune -o -not -path './.github/dependabot.yml' -type f \
-    -exec perl -pi -e "s/${src_org}\/${src_repo}/${dest_org}\/${dest_repo}/g" {} \; \
-    -exec perl -pi -e "s/${src_repo}/${dest_repo}/g" {} \;
+    -exec sed -i "s/${src_org}\/${src_repo}/${dest_org}\/${dest_repo}/g" {} \; \
+    -exec sed -i "s/${src_repo}/${dest_repo}/g" {} \;
 
   log_info "Staging modified files."
   git add --verbose .


### PR DESCRIPTION
## 🗣 Description ##

- This PR allows for a new repository from created from the skeleton to have a standard initial version such as 0.0.1 instead of inheriting and increment that of the old repository. 
- Refactored gh skeleton file to assign new version, stage and commit the new version

## 💭 Motivation and context ##

Closes #31 
This was done int he following commit
e4d7970
04baa36

## 🧪 Testing ##

All checks were passed
Tested remotely on GitHub UI

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
