### PR TITLE
Add support for resetting version to `0.0.1` in cloned repositories

### DIFF
--- a/gh-skeleton
+++ b/gh-skeleton
@@ -149,7 +149,7 @@ clone_repo() {
       done
 
       log_info "Staging version reset files."
-      git add --verbose $version_files
+      git add --verbose "$version_files"
       log_info "Committing version reset to the ${DEFAULT_BRANCH} branch."
       git commit --message "Reset version to 0.0.1 for new repository"
     fi

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -7,6 +7,7 @@ set -o pipefail
 DEFAULT_BRANCH="develop"
 DEST_ORG="cisagov"
 SRC_ORG="cisagov"
+VERSION_RESET="0.0.1"
 
 # Define terminal colors for use in logger functions.
 BLUE="\x1B[34m"
@@ -127,22 +128,22 @@ clone_repo() {
 
   log_info "Checking for bump-version script."
   if [ -f "./bump-version" ]; then
-    log_ok "bump-version script found. Resetting version to 0.0.1."
+    log_ok "bump-version script found. Resetting version to ${VERSION_RESET}."
 
     # Get the current version using bump-version
     current_version=$(./bump-version show)
     if [ -z "$current_version" ]; then
       log_error "Failed to determine current version. Skipping version reset."
     else
-      log_info "Current version is $current_version. Resetting to 0.0.1."
+      log_info "Current version is $current_version. Resetting to ${VERSION_RESET}."
 
-      # List version files and reset the version to 0.0.1
+      # List version files and reset the version to VERSION_RESET
       version_files=$(./bump-version --list-files)
       for version_file in $version_files; do
         if [ -f "$version_file" ]; then
-          log_info "Resetting version in $version_file to 0.0.1."
-          # Replace the current version with 0.0.1
-          perl -pi -e "s/${current_version//./\.}/0.0.1/g" "$version_file"
+          log_info "Resetting version in $version_file to ${VERSION_RESET}."
+          # Replace the current version with VERSION_RESET
+          perl -pi -e "s/${current_version//./\.}/${VERSION_RESET}/g" "$version_file"
         else
           log_warn "Expected version file $version_file not found."
         fi
@@ -151,7 +152,7 @@ clone_repo() {
       log_info "Staging version reset files."
       git add --verbose "$version_files"
       log_info "Committing version reset to the ${DEFAULT_BRANCH} branch."
-      git commit --message "Reset version to 0.0.1 for new repository"
+      git commit --message "Reset version to ${VERSION_RESET} for new repository"
     fi
   else
     log_warn "bump-version script not found. Skipping version reset."

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -134,6 +134,8 @@ clone_repo() {
     current_version=$(./bump-version show)
     if [ -z "$current_version" ]; then
       log_error "Failed to determine current version. Skipping version reset."
+    elif [ "$current_version" = "$VERSION_RESET" ]; then
+      log_ok "Current version is already ${VERSION_RESET}. Skipping version reset."
     else
       log_info "Current version is $current_version. Resetting to ${VERSION_RESET}."
 

--- a/gh-skeleton
+++ b/gh-skeleton
@@ -125,6 +125,38 @@ clone_repo() {
     -exec perl -pi -e "s/${src_org}\/${src_repo}/${dest_org}\/${dest_repo}/g" {} \; \
     -exec perl -pi -e "s/${src_repo}/${dest_repo}/g" {} \;
 
+  log_info "Checking for bump-version script."
+  if [ -f "./bump-version" ]; then
+    log_ok "bump-version script found. Resetting version to 0.0.1."
+
+    # Get the current version using bump-version
+    current_version=$(./bump-version show)
+    if [ -z "$current_version" ]; then
+      log_error "Failed to determine current version. Skipping version reset."
+    else
+      log_info "Current version is $current_version. Resetting to 0.0.1."
+
+      # List version files and reset the version to 0.0.1
+      version_files=$(./bump-version --list-files)
+      for version_file in $version_files; do
+        if [ -f "$version_file" ]; then
+          log_info "Resetting version in $version_file to 0.0.1."
+          # Replace the current version with 0.0.1
+          perl -pi -e "s/${current_version//./\.}/0.0.1/g" "$version_file"
+        else
+          log_warn "Expected version file $version_file not found."
+        fi
+      done
+
+      log_info "Staging version reset files."
+      git add --verbose $version_files
+      log_info "Committing version reset to the ${DEFAULT_BRANCH} branch."
+      git commit --message "Reset version to 0.0.1 for new repository"
+    fi
+  else
+    log_warn "bump-version script not found. Skipping version reset."
+  fi
+
   log_info "Staging modified files."
   git add --verbose .
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request introduces a new feature to reset the version number to `0.0.1` when creating a new repository from a skeleton repository. The `bump-version` script, if present, is used to identify and reset the relevant version files.

The implementation includes:
- Adding a constant `VERSION_RESET` to hold the version value `0.0.1`.
- Using `perl` to update the version in specified files while handling any potential non-numeric characters.
- Improved clarity and maintainability of the version reset logic.

## 💭 Motivation and context ##

This change is required to standardize the version of new repositories cloned from a skeleton, ensuring they start from a baseline version (`0.0.1`). This avoids accidental version mismatches or improper versioning history in new projects.

The solution leverages the existing `bump-version` script, if available, to determine the files to update, ensuring consistency and reducing manual intervention.

See:
- #31 
- #37

Closes #31 
Supersedes #37 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested clone of packer skeleton that had the new `bump-version` script implementation.
See:
- https://github.com/cisagov/skeleton-packer/pull/377

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
