### PR TITLE
Adjust the logic for getting the list of version files to reset

### DIFF
--- a/gh-skeleton
+++ b/gh-skeleton
@@ -139,9 +139,14 @@ clone_repo() {
     else
       log_info "Current version is $current_version. Resetting to ${VERSION_RESET}."
 
-      # List version files and reset the version to VERSION_RESET
-      version_files=$(./bump-version --list-files)
-      for version_file in $version_files; do
+      # Get the list of version files
+      version_files=()
+      while IFS= read -r line; do
+        version_files+=("$line")
+      done < <(./bump-version --list-files)
+
+      # Reset the version to VERSION_RESET for each version file
+      for version_file in "${version_files[@]}"; do
         if [ -f "$version_file" ]; then
           log_info "Resetting version in $version_file to ${VERSION_RESET}."
           # Replace the current version with VERSION_RESET
@@ -152,7 +157,7 @@ clone_repo() {
       done
 
       log_info "Staging version reset files."
-      git add --verbose "$version_files"
+      git add --verbose "${version_files[@]}"
       log_info "Committing version reset to the ${DEFAULT_BRANCH} branch."
       git commit --message "Reset version to ${VERSION_RESET} for new repository"
     fi


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request fixes a bug in how the list of version files to update is gathered.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Previously the result of `./bump-version --list-files` was treated as a single string value instead of multiple string values. This resulted in the later `git add` call erroring out when run against a repository with more than one file that contains version information.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that using this extension with a parent skeleton whose `./bump-version --list-files` call returns more than one file worked as expected.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
