### PR TITLE
Do not update references in the `.github` subdirectory

### DIFF
--- a/gh-skeleton
+++ b/gh-skeleton
@@ -122,7 +122,7 @@ clone_repo() {
   git remote set-url --push "${src_repo}" no_push
 
   log_info "Searching and replacing repository name in source files."
-  find . -path './.git' -prune -o -not -path './.github/dependabot.yml' -type f \
+  find . \( -path './.git' -prune -o -path './.github' -prune \) -o -type f \
     -exec perl -pi -e "s/${src_org}\/${src_repo}/${dest_org}\/${dest_repo}/g" {} \; \
     -exec perl -pi -e "s/${src_repo}/${dest_repo}/g" {} \;
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the logic for finding and replacing repository references to completely ignore the `.github/` subdirectory.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Right now we only exclude the `.github/dependabot.yml` file specifically. However, there are no repository references in files found within the `.github/` subdirectory that should be updated. This resolves #42.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that a freshly cloned repository using this branch did not have changes to files within the `.github/` subdirectory.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
